### PR TITLE
Add NodeX Emperor gentx

### DIFF
--- a/side-testnet-3/gentxs/NodeX.json
+++ b/side-testnet-3/gentxs/NodeX.json
@@ -1,0 +1,62 @@
+{
+   "body": {
+      "messages": [
+         {
+            "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+            "description": {
+               "moniker": "NodeX Emperor",
+               "identity": "D47444F2EF3D9308",
+               "website": "https://docs.nodex.one",
+               "security_contact": "hello@nodex.one",
+               "details": "NodeX Emperor is your reliable Proof-of-Stake validator in the Cosmos universe."
+            },
+            "commission": {
+               "rate": "0.100000000000000000",
+               "max_rate": "0.200000000000000000",
+               "max_change_rate": "0.100000000000000000"
+            },
+            "min_self_delegation": "1",
+            "delegator_address": "bc1kzvjz9lgevfd2kmh4qshxg4vshhxzd3pksm3xq",
+            "validator_address": "bcvaloper1kzvjz9lgevfd2kmh4qshxg4vshhxzd3pjn36d0",
+            "pubkey": {
+               "@type": "/cosmos.crypto.ed25519.PubKey",
+               "key": "xQJcHW0OZ7ofjhB9xxQUChoyjDeoo0J0iD6de/7EPqA="
+            },
+            "value": {
+               "denom": "uside",
+               "amount": "100000000"
+            }
+         }
+      ],
+      "memo": "e05097db7d40b7e65de48a44ecd544fa707f0641@136.243.104.103:26656",
+      "timeout_height": "0",
+      "extension_options": [],
+      "non_critical_extension_options": []
+   },
+   "auth_info": {
+      "signer_infos": [
+         {
+            "public_key": {
+               "@type": "/cosmos.crypto.secp256k1.PubKey",
+               "key": "AwIkRo27WEno+iqbeRj2uTzx5LlQiiUvbym/J3gu1gbv"
+            },
+            "mode_info": {
+               "single": {
+                  "mode": "SIGN_MODE_DIRECT"
+               }
+            },
+            "sequence": "0"
+         }
+      ],
+      "fee": {
+         "amount": [],
+         "gas_limit": "200000",
+         "payer": "",
+         "granter": ""
+      },
+      "tip": null
+   },
+   "signatures": [
+      "YnRZuLJr1NS7rXJuFgr5U+3w5pJvgIuVk4UU0N/7SkpJCd/4rEDuBbMkY6i8k+lySGZe/pDzKBpnkXFVxqHSpg=="
+   ]
+}


### PR DESCRIPTION
From now on we have made extensive updates to our services for side testnet network!

- Public RPC: Updated daily
- Various public endpoints are accessible
- Seed node, live peer, and Statesync are part of our offering
- We provide manual installation along with a comprehensive setup guide
- Valuable add-on services, including snapshots, addrbook, and more, are available

Explore more in our docs: 
- https://docs.nodex.one/networks/testnet/side (will switch to side-testnet-3 soon)