### PR TITLE
Typo Update validate-gentx.sh

### DIFF
--- a/scripts/validate-gentx.sh
+++ b/scripts/validate-gentx.sh
@@ -24,17 +24,17 @@ current=$(date +%Y-%m-%d\ %H:%M:%S)
 curTime=$(date --date="$current" +%s)
 
 if [[ $curTime < $stTime ]]; then
-    echo "start=$stTime:curent=$curTime:endTime=$endTime"
+    echo "start=$stTime:current=$curTime:endTime=$endTime"
     echo "Gentx submission is not open yet. Please close the PR and raise a new PR after 04-June-2021 23:59:59"
     exit 0
 else
     if [[ $curTime > $endTime ]]; then
-        echo "start=$stTime:curent=$curTime:endTime=$endTime"
+        echo "start=$stTime:current=$curTime:endTime=$endTime"
         echo "Gentx submission is closed"
         exit 0
     else
         echo "Gentx is now open"
-        echo "start=$stTime:curent=$curTime:endTime=$endTime"
+        echo "start=$stTime:current=$curTime:endTime=$endTime"
     fi
 fi
 


### PR DESCRIPTION
**Description**:
This pull request addresses a minor but important typo in the script. The word `curent` was incorrectly used instead of `current` in the output of the script. This change ensures that the script prints the correct word when displaying timestamps, enhancing the clarity and readability of the logs.

### **Changes**:
- Replaced the misspelled word `curent` with the correct `current` in the line that prints the current time in relation to the start and end times:
  ```bash
  echo "start=$stTime:current=$curTime:endTime=$endTime"
  ```

### **Why is this change important?**:
- While this typo does not affect the functionality of the script, correcting it helps ensure that the output is accurate and professional. This is particularly important for clarity when troubleshooting or reviewing the log outputs, as "curent" could be confusing or misleading.
- This change improves the consistency of the language in the script and prevents any misunderstandings during manual or automated reviews.
