### PR TITLE
Remove extra dot in shuttler release tag (tss.md)

### DIFF
--- a/sidechain-testnet-5/tss.md
+++ b/sidechain-testnet-5/tss.md
@@ -49,7 +49,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 git clone https://github.com/sideprotocol/shuttler.git
 cd shuttler
-git checkout v2.0.0-rc.1
+git checkout v2.0.0-rc1
 cargo build --release
 ```
 


### PR DESCRIPTION
There is a small typo in the release tag. The actual release tag doesn't  have a `.` after rc.
https://github.com/sideprotocol/shuttler/releases/tag/v2.0.0-rc1
